### PR TITLE
Fix OpenShift container entrypoint

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -10,4 +10,4 @@ COPY --from=0 /go/src/github.com/kubernetes-csi/external-provisioner/csi-provisi
 RUN useradd csi-provisioner
 USER csi-provisioner
 
-CMD ["/usr/bin/csi-provisioner"]
+ENTRYPOINT ["/usr/bin/csi-provisioner"]


### PR DESCRIPTION
It's now possible to run the image with "--v=5"