### PR TITLE
Rename OWNER alias

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- openshift-maintainers
+- openshift-storage-maintainers
 - saad-ali
 - childsb
 - lpabon

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,5 +1,5 @@
 aliases:
-  openshift-maintainers:
+  openshift-storage-maintainers:
     - jsafrane
     - tsmetana
     - gnufied


### PR DESCRIPTION
 
Alias name is used on various places (e.g. github.com/openshift/release),
so make sure it contains 'storage' in its name.