### PR TITLE
UPSTREAM: 369: Build Windows only for amd64

### DIFF
--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -57,13 +57,17 @@ else
 TESTARGS =
 endif
 
+ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
+
 # Specific packages can be excluded from each of the tests below by setting the *_FILTER_CMD variables
 # to something like "| grep -v 'github.com/kubernetes-csi/project/pkg/foobar'". See usage below.
 
 build-%:
 	mkdir -p bin
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$* ./cmd/$*
-	CGO_ENABLED=0 GOOS=windows go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$*.exe ./cmd/$*
+	if [ "$$ARCH" = "amd64" ]; then \
+		CGO_ENABLED=0 GOOS=windows go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$*.exe ./cmd/$* ; \
+	fi
 
 container-%: build-%
 	docker build -t $*:latest -f $(shell if [ -e ./cmd/$*/Dockerfile ]; then echo ./cmd/$*/Dockerfile; else echo Dockerfile; fi) --label revision=$(REV) .

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -183,7 +183,7 @@ configvar CSI_PROW_WORK "$(mkdir -p "$GOPATH/pkg" && mktemp -d "$GOPATH/pkg/csip
 #
 # When no deploy script is found (nothing in `deploy` directory,
 # CSI_PROW_HOSTPATH_REPO=none), nothing gets deployed.
-configvar CSI_PROW_HOSTPATH_VERSION "v1.2.0-rc2" "hostpath driver"
+configvar CSI_PROW_HOSTPATH_VERSION "v1.2.0-rc8" "hostpath driver"
 configvar CSI_PROW_HOSTPATH_REPO https://github.com/kubernetes-csi/csi-driver-host-path "hostpath repo"
 configvar CSI_PROW_DEPLOYMENT "" "deployment"
 configvar CSI_PROW_HOSTPATH_DRIVER_NAME "hostpath.csi.k8s.io" "the hostpath driver name"
@@ -759,6 +759,8 @@ DriverInfo:
     persistence: true
     dataSource: true
     multipods: true
+    nodeExpansion: true
+    controllerExpansion: true
 EOF
 }
 


### PR DESCRIPTION
Trying to merge just enough patches from csi-release-tools repo to fix the
Windows build in ART jobs. It merges also unrelated HostPath changes.

`make test` checks, that `release-tools/` contains only merge commits and
therefore cherry-pick cannot be used.

cc @openshift/storage 