### PR TITLE
Bug 1956768: UPSTREAM: 620: Fix migration metric registration

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -222,7 +222,10 @@ func main() {
 		klog.V(2).Infof("Supports migration from in-tree plugin: %s", supportsMigrationFromInTreePluginName)
 
 		// Create a new connection with the metrics manager with migrated label
-		metricsManager = metrics.NewCSIMetricsManagerWithOptions(provisionerName, metrics.WithMigration())
+		metricsManager = metrics.NewCSIMetricsManagerWithOptions(provisionerName,
+			// Will be provided via default gatherer.
+			metrics.WithProcessStartTime(false),
+			metrics.WithMigration())
 		migratedGrpcClient, err := ctrl.Connect(*csiEndpoint, metricsManager)
 		if err != nil {
 			klog.Error(err.Error())


### PR DESCRIPTION
Don't register `process_start_time_seconds` metric in migration metrics manager to prevent double registration, resulting in this error:

```
gathered metric family process_start_time_seconds has help "[ALPHA] Start time of the process since unix epoch in seconds." but should have "Start time of the process since unix epoch in seconds."
```

cc @openshift/storage 