### PR TITLE
Bug 2101343: UPSTREAM: 2101343: fix: changed the csistoragecapacity check namespace

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -493,7 +493,7 @@ func main() {
 				Name: "#%123-invalid-name",
 			},
 		}
-		createdCapacity, err := clientset.StorageV1().CSIStorageCapacities("default").Create(ctx, invalidCapacity, metav1.CreateOptions{})
+		createdCapacity, err := clientset.StorageV1().CSIStorageCapacities(namespace).Create(ctx, invalidCapacity, metav1.CreateOptions{})
 		switch {
 		case err == nil:
 			klog.Fatalf("creating an invalid v1.CSIStorageCapacity didn't fail as expected, got: %s", createdCapacity)


### PR DESCRIPTION
Cherry-pick of https://github.com/kubernetes-csi/external-provisioner/pull/753 to 4.12.

The CSIStorageCapacity v1 check was attampting to create an invalid
object in the default namespace. This would fail if the pod did not
have permissions to the namespace. This will now use the namespace
specified in the NAMESPACE env variable.


cc @openshift/storage 