### PR TITLE
OCPBUGS-27242: fix or ignore snyk errors for ocp storage repos

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,4 @@
 exclude:
   global:
     - vendor/**
+    - release-tools/**


### PR DESCRIPTION
Ignore these errors, release-tools is not part of the component that runs in production, and these reported issues do not grant the caller any extra permissions. If you can read it with release-tools then you already have access to read it without release-tools.

```
 ✗ [Medium] Path Traversal
   ID: 3fc8046c-130d-47bf-b9d9-82031d8fbb02 
   Path: release-tools/filter-junit.go, line 98 
   Info: Unsanitized input from a CLI argument flows into os.ReadFile, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
 ✗ [Medium] Path Traversal
   ID: 2e81599a-d493-4db8-9835-c0606f80df2a 
   Path: release-tools/filter-junit.go, line 145 
   Info: Unsanitized input from a CLI argument flows into os.WriteFile, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to write arbitrary files.
 ✗ [Medium] Path Traversal
   ID: a20c42f1-44d5-45a2-84dd-acc9060eae9e 
   Path: release-tools/boilerplate/boilerplate.py, line 59 
   Info: Unsanitized input from a command line argument flows into open, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
 ✗ [Medium] Path Traversal
   ID: a903d19e-ee2a-4b85-af57-10eba2409e2d 
   Path: release-tools/boilerplate/boilerplate.py, line 150 
   Info: Unsanitized input from a command line argument flows into os.walk, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
```

from https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/47618/rehearse-47618-pull-ci-openshift-csi-external-provisioner-master-security/1745954192519860224

/cc @openshift/storage
