### PR TITLE
OCPBUGS-49805: Fix the managed-by-label getting populated with invalid value

### DIFF
--- a/cmd/csi-provisioner/util.go
+++ b/cmd/csi-provisioner/util.go
@@ -28,7 +28,11 @@ import (
 // it will truncate the base, add the hash of the base and return [base]-[hash]-[suffix]
 // copied from https://github.com/openshift/library-go/blob/master/pkg/build/naming/namer.go
 func getNameWithMaxLength(base, suffix string, maxLength int) string {
-	name := fmt.Sprintf("%s-%s", base, suffix)
+	name := suffix
+	if base != "" {
+		name = fmt.Sprintf("%s-%s", base, suffix)
+	}
+
 	if len(name) <= maxLength {
 		return name
 	}
@@ -36,10 +40,13 @@ func getNameWithMaxLength(base, suffix string, maxLength int) string {
 	baseLength := maxLength - 10 /*length of -hash-*/ - len(suffix)
 
 	// if the suffix is too long, ignore it
-	if baseLength < 0 {
+	if baseLength <= 0 {
+		shortName := hash(name)
 		prefix := base[0:min(len(base), max(0, maxLength-9))]
-		// Calculate hash on initial base-suffix string
-		shortName := fmt.Sprintf("%s-%s", prefix, hash(name))
+		if prefix != "" {
+			// Calculate hash on initial base-suffix string
+			shortName = fmt.Sprintf("%s-%s", prefix, hash(name))
+		}
 		return shortName[:min(maxLength, len(shortName))]
 	}
 

--- a/cmd/csi-provisioner/util_test.go
+++ b/cmd/csi-provisioner/util_test.go
@@ -30,30 +30,56 @@ func TestGetNameWithMaxLength(t *testing.T) {
 	testcases := map[string]struct {
 		expected string
 		nodeName string
+		base     string
 	}{
 		"unchanged": {
 			expected: fmt.Sprintf("%s-%s", externalProvisioner, "node01"),
 			nodeName: "node01",
+			base:     externalProvisioner,
+		},
+		"with empty base": {
+			expected: fmt.Sprintf("%s", "node01"),
+			nodeName: "node01",
+			base:     "",
 		},
 		"exactly63": {
 			// 20 (external-provisioner) + 1 (-) + 4 (node) + 38 = 63
 			expected: fmt.Sprintf("%s-%s", externalProvisioner, fmt.Sprintf("node%s", strings.Repeat("a", 38))),
 			nodeName: fmt.Sprintf("node%s", strings.Repeat("a", 38)),
+			base:     externalProvisioner,
 		},
 		"one over": {
 			expected: fmt.Sprintf("%s-%s-%s", "external-p", "53f40b57", fmt.Sprintf("node%s", strings.Repeat("a", 39))),
 			nodeName: fmt.Sprintf("node%s", strings.Repeat("a", 39)),
+			base:     externalProvisioner,
+		},
+		"long node name with 52": {
+			expected: fmt.Sprintf("%s-%s-%s", "e", "53f40b57", fmt.Sprintf("node%s", strings.Repeat("a", 48))),
+			nodeName: fmt.Sprintf("node%s", strings.Repeat("a", 48)),
+			base:     externalProvisioner,
+		},
+
+		"long node name with 53, ignore suffix ": {
+			expected: fmt.Sprintf("%s-%s", externalProvisioner, "a3607ff1"),
+			nodeName: fmt.Sprintf("node%s", strings.Repeat("a", 49)),
+			base:     externalProvisioner,
 		},
 		"very long, ignore suffix": {
 			expected: fmt.Sprintf("%s-%s", externalProvisioner, "df38e37f"),
 			nodeName: fmt.Sprintf("node%s", strings.Repeat("a", 63)),
+			base:     externalProvisioner,
+		},
+		"long node name ,with empty base": {
+			expected: fmt.Sprintf("%s", "fa65587e"),
+			nodeName: fmt.Sprintf("node%s", strings.Repeat("a", 63)),
+			base:     "",
 		},
 	}
 
 	for name, c := range testcases {
 		t.Run(name, func(t *testing.T) {
 			expected := c.expected
-			res := getNameWithMaxLength(externalProvisioner, c.nodeName, 63)
+			res := getNameWithMaxLength(c.base, c.nodeName, 63)
 			if expected != res {
 				t.Errorf("Expected: %s, does not match result: %s", expected, res)
 			}


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-49805
Cherry pick of upstream's https://github.com/kubernetes-csi/external-provisioner/pull/1334