### PR TITLE
WIP: debug go version failure in vsphere presubmit jobs

### DIFF
--- a/Dockerfile.openshift.rhel7
+++ b/Dockerfile.openshift.rhel7
@@ -1,6 +1,8 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/github.com/kubernetes-csi/external-provisioner
 COPY . .
+RUN go version
+RUN which go
 RUN make build
 
 FROM registry.ci.openshift.org/ocp/4.17:base-rhel9

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-csi/external-provisioner
 
-go 1.22.3
+go 1.22.0
 
 require (
 	github.com/container-storage-interface/spec v1.9.0


### PR DESCRIPTION
For debugging failures seen in https://github.com/openshift/csi-external-provisioner/pull/142 ([example](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_csi-external-provisioner/142/pull-ci-openshift-csi-external-provisioner-release-4.17-e2e-vsphere-csi/2072657942846377984)).
